### PR TITLE
Add publish scripts

### DIFF
--- a/.scripts/publish.js
+++ b/.scripts/publish.js
@@ -1,0 +1,19 @@
+const semver = require("semver");
+const util = require("util");
+const cp= require("child_process");
+const exec=util.promisify(cp.exec);
+
+async function main() {
+  const package_json = require("../package.json");
+  const baseVersion = (package_json.version).trim()
+  const v = (await exec("git rev-list --parents HEAD --count --full-history")).stdout.trim();
+
+  const version = `${semver.major(baseVersion)}.${semver.minor(baseVersion)}.${v}`
+
+  console.log(`Using version ${version}`);
+  process.argv.push(`publish`,`--access`,`public`,`--tag`,`preview`,`--new-version`,`${version}`, `--no-git-tag-version`);
+  // now, on with the publish...
+  require( "yarn/lib/cli.js" );
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test": "run-p test:tslint test:unit",
     "test:unit": "mocha",
     "test:tslint": "tslint -p . -c tslint.json --exclude test/**/*.ts",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "publish-preview": "npm test && shx rm -rf dist/test && node ./.scripts/publish"
   }
 }


### PR DESCRIPTION
Shortly after this I will merge the changes made in the GithubReference branch to master and update the package.json for ms-rest-azure-js to depend on the latest ms-rest-js.

Is manually specifying that later version of ms-rest-js in ms-rest-azure-js as needed probably going to be the way forward for us? What do you guys think @amarzavery @daschult ?