### PR TITLE
Add scripts for manipulating ms-rest-js version

### DIFF
--- a/.scripts/dependencies.js
+++ b/.scripts/dependencies.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+function updatePackageJsonDependency(dependencyName, dependencyVersion) {
+  const packageJsonFilePath = path.resolve(__dirname, "../package.json");
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonFilePath));
+  if (packageJson.dependencies[dependencyName] == dependencyVersion) {
+    console.log(`"${dependencyName}" is already set to "${dependencyVersion}".`);
+  } else {
+    console.log(`Changing "${dependencyName}" to "${dependencyVersion}"`)
+    packageJson.dependencies[dependencyName] = dependencyVersion;
+
+    fs.writeFileSync(packageJsonFilePath, JSON.stringify(packageJson, undefined, "  "));
+
+    const npmInstallCommand = `npm install ${dependencyName}`;
+    console.log(npmInstallCommand);
+    execSync(npmInstallCommand, {stdio:[0,1,2]});
+  }
+}
+
+function getNpmPackageVersion(packageName, tag) {
+  const npmViewResult = JSON.parse(execSync(`npm view ${packageName} --json`, { stdio: ['pipe', 'pipe', 'ignore'] }));
+  return npmViewResult['dist-tags'][tag];
+}
+
+exports.updatePackageJsonDependency = updatePackageJsonDependency;
+exports.getNpmPackageVersion = getNpmPackageVersion;

--- a/.scripts/dependencies.js
+++ b/.scripts/dependencies.js
@@ -2,10 +2,76 @@ const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
-function updatePackageJsonDependency(dependencyName, dependencyVersion) {
-  const packageJsonFilePath = path.resolve(__dirname, "../package.json");
+/**
+ * Get the absolute path to the package.json in this repository.
+ * @returns {string} The absolute path to the package.json.
+ */
+function getPackageJsonFilePath() {
+  return path.resolve(__dirname, "../package.json");
+}
 
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonFilePath));
+/**
+ * Get the package.json file contents parsed as a JSON object.
+ * @param {string=} packageJsonFilePath The path to the package.json file to read. If this is not
+ * provided, then the package.json file at the root of this repository will be used.
+ * @returns {{}} The parsed package.json file contents.
+ */
+function getPackageJson(packageJsonFilePath) {
+  if (!packageJsonFilePath) {
+    packageJsonFilePath = getPackageJsonFilePath();
+  }
+  return JSON.parse(fs.readFileSync(packageJsonFilePath));
+}
+
+/**
+ * Get the dependencies from the provided dependencies dictionary that have local clones.
+ * @param {{ [packageName: string]: string }} dependencies A dictionary of package names to package
+ * versions.
+ * @param {string[]} clonedRepositoryNames The array to put the names of the local cloned
+ * repositories into.
+ * @returns {void}
+ */
+function getClonedRepositories(dependencies, clonedRepositoryNames) {
+  if (clonedRepositoryNames && dependencies) {
+    for (const dependencyName in dependencies) {
+      if (clonedRepositoryNames.indexOf(dependencyName) === -1) {
+        const repoFolderPath = path.resolve(__dirname, "..", "..", dependencyName);
+        if (fs.existsSync(repoFolderPath)) {
+          clonedRepositoryNames.push(dependencyName);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Get the names of the dependencies of this repository that have local clones.
+ * @returns {string[]} The names of the dependencies of this repository that have local clones.
+ */
+function getDependenciesWithClonedRepositories() {
+  const clonedRepositoryNames = [];
+
+  const packageJson = getPackageJson();
+
+  getClonedRepositories(packageJson.dependencies, clonedRepositoryNames);
+  getClonedRepositories(packageJson.devDependencies, clonedRepositoryNames);
+
+  return clonedRepositoryNames;
+}
+exports.getDependenciesWithClonedRepositories = getDependenciesWithClonedRepositories;
+
+/**
+ * Update this repository's package.json file's dependency version with the provided name to the
+ * provided version. If the dependency version in the package.json file changes, then "npm install"
+ * will be run for the changed dependency.
+ * @param {string} dependencyName The name of the dependency to update.
+ * @param {string} dependencyVersion The version to update the dependency to.
+ * @returns {void}
+ */
+function updatePackageJsonDependency(dependencyName, dependencyVersion) {
+  const packageJsonFilePath = getPackageJsonFilePath();
+
+  const packageJson = getPackageJson(packageJsonFilePath);
   if (packageJson.dependencies[dependencyName] == dependencyVersion) {
     console.log(`"${dependencyName}" is already set to "${dependencyVersion}".`);
   } else {
@@ -19,11 +85,16 @@ function updatePackageJsonDependency(dependencyName, dependencyVersion) {
     execSync(npmInstallCommand, {stdio:[0,1,2]});
   }
 }
+exports.updatePackageJsonDependency = updatePackageJsonDependency;
 
+/**
+ * Get the npm package version of the package with the provided name at the provided tag.
+ * @param {string} packageName The name of the package.
+ * @param {string} tag The tag of the version to retrieve.
+ * @returns {string?} The version of the provided package at the provided tag.
+ */
 function getNpmPackageVersion(packageName, tag) {
   const npmViewResult = JSON.parse(execSync(`npm view ${packageName} --json`, { stdio: ['pipe', 'pipe', 'ignore'] }));
   return npmViewResult['dist-tags'][tag];
 }
-
-exports.updatePackageJsonDependency = updatePackageJsonDependency;
 exports.getNpmPackageVersion = getNpmPackageVersion;

--- a/.scripts/latest.js
+++ b/.scripts/latest.js
@@ -1,0 +1,4 @@
+const dependencies = require("./dependencies");
+
+const previewVersion = dependencies.getNpmPackageVersion("ms-rest-js", "latest");
+dependencies.updatePackageJsonDependency("ms-rest-js", `^${previewVersion}`);

--- a/.scripts/latest.js
+++ b/.scripts/latest.js
@@ -1,4 +1,7 @@
 const dependencies = require("./dependencies");
 
-const previewVersion = dependencies.getNpmPackageVersion("ms-rest-js", "latest");
-dependencies.updatePackageJsonDependency("ms-rest-js", `^${previewVersion}`);
+const localDependencies = dependencies.getDependenciesWithClonedRepositories();
+for (const localDependency of localDependencies) {
+  const version = dependencies.getNpmPackageVersion(localDependency, "latest");
+  dependencies.updatePackageJsonDependency(localDependency, `^${version}`);
+}

--- a/.scripts/local.js
+++ b/.scripts/local.js
@@ -1,3 +1,6 @@
 const dependencies = require("./dependencies");
 
-dependencies.updatePackageJsonDependency("ms-rest-js", "file:../ms-rest-js");
+const localDependencies = dependencies.getDependenciesWithClonedRepositories();
+for (const localDependency of localDependencies) {
+  dependencies.updatePackageJsonDependency(localDependency, `file:../${localDependency}`);
+}

--- a/.scripts/local.js
+++ b/.scripts/local.js
@@ -1,0 +1,3 @@
+const dependencies = require("./dependencies");
+
+dependencies.updatePackageJsonDependency("ms-rest-js", "file:../ms-rest-js");

--- a/.scripts/preview.js
+++ b/.scripts/preview.js
@@ -1,4 +1,10 @@
 const dependencies = require("./dependencies");
 
-const previewVersion = dependencies.getNpmPackageVersion("ms-rest-js", "preview");
-dependencies.updatePackageJsonDependency("ms-rest-js", `^${previewVersion}`);
+const localDependencies = dependencies.getDependenciesWithClonedRepositories();
+for (const localDependency of localDependencies) {
+  let version = dependencies.getNpmPackageVersion(localDependency, "preview");
+  if (!version) {
+    version = dependencies.getNpmPackageVersion(localDependency, "latest");
+  }
+  dependencies.updatePackageJsonDependency(localDependency, `^${version}`);
+}

--- a/.scripts/preview.js
+++ b/.scripts/preview.js
@@ -1,0 +1,4 @@
+const dependencies = require("./dependencies");
+
+const previewVersion = dependencies.getNpmPackageVersion("ms-rest-js", "preview");
+dependencies.updatePackageJsonDependency("ms-rest-js", `^${previewVersion}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,9 +73,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.16.tgz",
-      "integrity": "sha512-fwUW7S8gaSVNpPa1XUdzI0URY71xqXsc90S9vKr2uFIUpVCKV+8ysnN9vvAFK8np4H03A7QGRkHpQvgah0964Q=="
+      "version": "9.6.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.17.tgz",
+      "integrity": "sha512-K/pOQpXevFVZYFWI+Oi6yDzVv4j665eEW3w5pXa/GOfWi7kwzHiSkX1kMEDwoAe0LcHFIOIezgOQfXfUXd392Q=="
     },
     "@types/node-fetch": {
       "version": "1.6.9",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "types": "./typings/lib/msRestAzure.d.ts",
   "license": "MIT",
   "dependencies": {
-    "ms-rest-js": "0.5.143"
+    "ms-rest-js": "^0.5.143"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.43",
@@ -64,6 +64,9 @@
     "test:unit": "mocha",
     "test:tslint": "tslint -p . -c tslint.json --exclude test/**/*.ts",
     "prepare": "npm run build",
-    "publish-preview": "npm test && shx rm -rf dist/test && node ./.scripts/publish"
+    "publish-preview": "npm test && shx rm -rf dist/test && node ./.scripts/publish",
+    "local": "node ./.scripts/local.js",
+    "preview": "node ./.scripts/preview.js",
+    "latest": "node ./.scripts/latest.js"
   }
 }


### PR DESCRIPTION
These little scripts can be run to manipulate the version of ms-rest-js that this package is targeting. My vision is to reproduce this in autorest.typescript and then to chain them together so that you can run `npm run local` from autorest.typescript and it will update the dependency versions in autorest.typescript and in ms-rest-azure-js too. I feel that this will definitely speed up my development process.