### PR TITLE
Add type annotations to built in mappers

### DIFF
--- a/lib/baseResource.ts
+++ b/lib/baseResource.ts
@@ -1,3 +1,5 @@
+import { CompositeMapper } from "ms-rest-js";
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
@@ -7,7 +9,7 @@
  */
 export interface BaseResource { }
 
-export const BaseResourceMapper = {
+export const BaseResourceMapper: CompositeMapper = {
   serializedName: "BaseResource",
   type: {
     name: "Composite",

--- a/lib/baseResource.ts
+++ b/lib/baseResource.ts
@@ -1,7 +1,7 @@
-import { CompositeMapper } from "ms-rest-js";
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { CompositeMapper } from "ms-rest-js";
 
 /**
  * @class

--- a/lib/cloudError.ts
+++ b/lib/cloudError.ts
@@ -1,7 +1,7 @@
-import { CompositeMapper } from "ms-rest-js";
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { CompositeMapper } from "ms-rest-js";
 
 /**
  * @class

--- a/lib/cloudError.ts
+++ b/lib/cloudError.ts
@@ -1,3 +1,5 @@
+import { CompositeMapper } from "ms-rest-js";
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
@@ -24,7 +26,7 @@ export interface CloudError extends Error {
   details?: Array<CloudError>;
 }
 
-export const CloudErrorMapper = {
+export const CloudErrorMapper: CompositeMapper = {
   serializedName: "CloudError",
   type: {
     name: "Composite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,9 +175,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.23.tgz",
-      "integrity": "sha512-d2SJJpwkiPudEQ3+9ysANN2Nvz4QJKUPoe/WL5zyQzI0RaEeZWH5K5xjvUIGszTItHQpFPdH+u51f6G/LkS8Cg=="
+      "version": "9.6.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.24.tgz",
+      "integrity": "sha512-o5K0mt8x735EaqS7F2x+5AG0b1Mt3V9jgV5SeW8SD6RNhE++dvwqLf2R2e4c8FmhNLaogz2oXrsiXnqnsBSSIQ=="
     },
     "@types/range-parser": {
       "version": "1.2.2",
@@ -691,9 +691,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "buffer-xor": {
@@ -2924,9 +2924,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "ms-rest-js": {
-      "version": "0.16.374",
-      "resolved": "https://registry.npmjs.org/ms-rest-js/-/ms-rest-js-0.16.374.tgz",
-      "integrity": "sha1-c009DinsWgZy8QZqRnVi2m2wtYw=",
+      "version": "0.17.375",
+      "resolved": "https://registry.npmjs.org/ms-rest-js/-/ms-rest-js-0.17.375.tgz",
+      "integrity": "sha1-oRwWS6O8mo45DFNTliOfqTgIysQ=",
       "requires": {
         "@types/express": "^4.11.1",
         "@types/form-data": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "types": "./typings/lib/msRestAzure.d.ts",
   "license": "MIT",
   "dependencies": {
-    "ms-rest-js": "~0.16.374",
+    "ms-rest-js": "~0.17.375",
     "tslib": "^1.9.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-azure-js"
   },
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Isomorphic Azure client runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
Depends on Azure/ms-rest-js#180