### PR TITLE
Grab credentials.environment.baseUri if present

### DIFF
--- a/lib/azureServiceClient.ts
+++ b/lib/azureServiceClient.ts
@@ -41,6 +41,13 @@ export class AzureServiceClient extends ServiceClient {
   constructor(credentials: ServiceClientCredentials, options?: AzureServiceClientOptions) {
     super(credentials, options = updateOptionsWithDefaultValues(options));
 
+    // For convenience, if the credentials have an associated AzureEnvironment,
+    // automatically use the baseUri from that environment.
+    const env = (credentials as any).environment;
+    if (env && !this.baseUri) {
+      this.baseUri = env.resourceManagerEndpointUrl;
+    }
+
     if (options.acceptLanguage != undefined) {
       this.acceptLanguage = options.acceptLanguage;
     }

--- a/test/azureServiceClientTests.ts
+++ b/test/azureServiceClientTests.ts
@@ -30,6 +30,16 @@ describe("AzureServiceClient", () => {
       assert.strictEqual(client.longRunningOperationRetryTimeout, 2);
       assert.deepStrictEqual(client.userAgentInfo, { value: ["ms-rest-js/0.1.0", "ms-rest-azure/0.1.0"] });
     });
+
+    it("should apply the resourceManagerEndpointUrl from credentials", async function() {
+      const creds = {
+        signRequest: (request: WebResource) => Promise.resolve(request),
+        environment: { resourceManagerEndpointUrl: "foo" }
+      };
+      const client = new AzureServiceClient(creds);
+      // accessing protected property by casting
+      assert.strictEqual((client as any).baseUri, "foo");
+    });
   });
 
   describe("sendLRORequest()", () => {


### PR DESCRIPTION
Doing similar work as Azure/azure-sdk-for-node#3278, just in the TypeScript SDKs.