### PR TITLE
Change browser to module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clientruntime"
   ],
   "main": "./dist/msRestAzure.js",
-  "browser": "./es/lib/msRestAzure.js",
+  "module": "./es/lib/msRestAzure.js",
   "types": "./es/lib/msRestAzure.d.ts",
   "files": [
     "dist/**/*.js",


### PR DESCRIPTION
./es/lib/msRestAzure.js is an entry point for all esm based tools so it's more useful to users to use the "module" field to point to it than the "browser" field.