### PR TITLE
Add better sourcemap support for debugging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1 - 2018-11-13
+
+- Improve debugging by adding rollup-plugin-sourcemaps
+
 ## 1.1.0 - 2018/11/09
 
 - Renamed NPM package to @azure/ms-rest-azure-js and updated renamed dependencies

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-azure-js"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Isomorphic Azure client runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@azure/ms-rest-js": "^1.1.0",
+    "@azure/ms-rest-js": "^1.1.1",
     "tslib": "^1.9.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "nyc": "^12.0.2",
     "rollup": "^0.66.4",
     "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-visualizer": "^0.9.2",
     "shx": "^0.2.2",
     "ts-loader": "^2.3.7",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import nodeResolve from "rollup-plugin-node-resolve";
 import visualizer from "rollup-plugin-visualizer";
+import sourcemaps from "rollup-plugin-sourcemaps";
 
 const banner = `/** @license ms-rest-azure-js
  * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -24,6 +25,7 @@ const config = {
   },
   plugins: [
     nodeResolve({ module: true }),
+    sourcemaps(),
     visualizer({ filename: "dist/node-stats.html", sourcemap: true })
   ]
 }


### PR DESCRIPTION
Resolves https://github.com/Azure/ms-rest-azure-js/issues/68.
Ever since we started bundling this package our debugging story has been that you have to write the code in TypeScript, but debug in JavaScript.
I looked around today and found the rollup-plugin-sourcemaps package that successfully maps the bundle back to the original TypeScript code. It makes for a much better debugging experience.