### PR TITLE
Use @azure/core-http instead of @azure/ms-rest-js

### DIFF
--- a/lib/azureServiceClient.ts
+++ b/lib/azureServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { HttpOperationResponse, OperationArguments, OperationSpec, RequestOptionsBase, RequestPrepareOptions, ServiceClient, ServiceClientCredentials, ServiceClientOptions, WebResource, getDefaultUserAgentValue as getDefaultUserAgentValueFromMsRest } from "@azure/ms-rest-js";
+import { HttpOperationResponse, OperationArguments, OperationSpec, RequestOptionsBase, RequestPrepareOptions, ServiceClient, ServiceClientCredentials, ServiceClientOptions, WebResource, getDefaultUserAgentValue as getDefaultUserAgentValueFromMsRest } from "@azure/core-http";
 import { createLROPollerFromInitialResponse, createLROPollerFromPollState, LROPoller } from "./lroPoller";
 import { LROPollState } from "./lroPollStrategy";
 import * as Constants from "./util/constants";

--- a/lib/baseResource.ts
+++ b/lib/baseResource.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { CompositeMapper } from "@azure/ms-rest-js";
+import { CompositeMapper } from "@azure/core-http";
 
 /**
  * @class

--- a/lib/cloudError.ts
+++ b/lib/cloudError.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { CompositeMapper } from "@azure/ms-rest-js";
+import { CompositeMapper } from "@azure/core-http";
 
 /**
  * @class

--- a/lib/credentials/cognitiveServicesCredentials.ts
+++ b/lib/credentials/cognitiveServicesCredentials.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { ApiKeyCredentials } from "@azure/ms-rest-js";
+import { ApiKeyCredentials } from "@azure/core-http";
 
 /**
  * Creates a new CognitiveServicesCredentials object.

--- a/lib/lroPollStrategy.ts
+++ b/lib/lroPollStrategy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { delay, HttpMethods, HttpOperationResponse, RequestOptionsBase, RestError, stripRequest, WebResource, OperationResponse, OperationSpec } from "@azure/ms-rest-js";
+import { delay, HttpMethods, HttpOperationResponse, RequestOptionsBase, RestError, stripRequest, WebResource, OperationResponse, OperationSpec } from "@azure/core-http";
 import { AzureServiceClient } from "./azureServiceClient";
 import { LongRunningOperationStates } from "./util/constants";
 

--- a/lib/lroPoller.ts
+++ b/lib/lroPoller.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { HttpOperationResponse, RequestOptionsBase, RestResponse, flattenResponse } from "@azure/ms-rest-js";
+import { HttpOperationResponse, RequestOptionsBase, RestResponse, flattenResponse } from "@azure/core-http";
 import { AzureServiceClient } from "./azureServiceClient";
 import { createLROPollStrategyFromInitialResponse, createLROPollStrategyFromPollState, LROPollState, LROPollStrategy } from "./lroPollStrategy";
 import { LongRunningOperationStates } from "./util/constants";

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@azure/ms-rest-js": "^1.8.10",
+    "@azure/core-http": "^1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-azure-js"
   },
-  "version": "1.3.8",
+  "version": "2.0.0-preview.1",
   "description": "Isomorphic Azure client runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,14 +12,14 @@ const banner = `/** @license ms-rest-azure-js
  */
 const config = {
   input: './es/lib/msRestAzure.js',
-  external: ["@azure/ms-rest-js"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/msRestAzure.js",
     format: "umd",
     name: "msRestAzure",
     sourcemap: true,
     globals: {
-      "@azure/ms-rest-js": "msRest"
+      "@azure/core-http": "Azure.Core.HTTP"
     },
     banner
   },

--- a/test/azureServiceClientTests.ts
+++ b/test/azureServiceClientTests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import assert from "assert";
-import { HttpHeaders, HttpOperationResponse, RequestOptionsBase, RestError, TokenCredentials, WebResource, OperationArguments, OperationSpec, Serializer } from "@azure/ms-rest-js";
+import { HttpHeaders, HttpOperationResponse, RequestOptionsBase, RestError, TokenCredentials, WebResource, OperationArguments, OperationSpec, Serializer } from "@azure/core-http";
 import { AzureServiceClient, AzureServiceClientOptions, updateOptionsWithDefaultValues } from "../lib/azureServiceClient";
 import * as msAssert from "./msAssert";
 import { LROPoller } from "../lib/lroPoller";

--- a/test/cloudErrorTests.ts
+++ b/test/cloudErrorTests.ts
@@ -1,4 +1,4 @@
-import { Serializer } from "@azure/ms-rest-js";
+import { Serializer } from "@azure/core-http";
 import { CloudErrorMapper, CloudError } from "../lib/cloudError";
 import { expect } from "chai";
 

--- a/test/credentials/cognitiveServicesCredentialsTests.ts
+++ b/test/credentials/cognitiveServicesCredentialsTests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import assert from "assert";
-import { WebResource } from "@azure/ms-rest-js";
+import { WebResource } from "@azure/core-http";
 import { CognitiveServicesCredentials } from "../../lib/credentials/cognitiveServicesCredentials";
 import * as msAssert from "../msAssert";
 

--- a/test/lroPollStrategyTests.ts
+++ b/test/lroPollStrategyTests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import assert from "assert";
-import { HttpHeaders, HttpOperationResponse, TokenCredentials, WebResource } from "@azure/ms-rest-js";
+import { HttpHeaders, HttpOperationResponse, TokenCredentials, WebResource } from "@azure/core-http";
 import { AzureServiceClient } from "../lib/azureServiceClient";
 import { getDelayInSeconds, isFinished } from "../lib/lroPollStrategy";
 


### PR DESCRIPTION
This PR updates this library to use @azure/core-http and bumps it to a new major preview version to indicate the change.  I'm creating this as a draft PR for now until we decide that we want to move forward with it!

/cc @bterlson @ramya-rao-a