### PR TITLE
update min version of dependency on ms-rest-js to 2.0.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,13 @@
 # Changelog
+## 2.0.0 - 2019-07-15
+- Bumping the version to `2.0.0` since the underlying dependency `@azure/ms-rest-js` has moved to `2.x.x` range.
+  - `@azure/ms-rest-js@2.x.x` is using `node-fetch` instead of `axios` as the http client for node.js scenario.
+  - We have made some bug fixes to handling cookie parsing errors in the `2.0.3` version
+  - This helps us in making it easier to update the autorest generated TypeScript sdk packages on an on-demand basis and keeping sdks from unnecessarily getting runtime updates when they are eventually going to get updated to use the new `@azure/core-*` runtime packages in couple of weeks from now.
+
+## 1.3.8 - 2019-06-06
+- Fixed tests to pass when -preview suffix set in version.
+
 ## 1.3.7 - 2019-06-04
 - Updated `@azure/ms-rest-js` to `^1.8.10`
 

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -27,4 +27,4 @@ export const DEFAULT_LANGUAGE = "en-us";
  * @const
  * @type {string}
  */
-export const msRestAzureVersion = "1.3.7";
+export const msRestAzureVersion = "2.0.0";

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-azure-js"
   },
-  "version": "1.3.8",
+  "version": "2.0.0",
   "description": "Isomorphic Azure client runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",
@@ -41,32 +41,32 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@azure/ms-rest-js": "^1.8.10",
-    "tslib": "^1.9.3"
+    "@azure/ms-rest-js": "^2.0.3",
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@ts-common/azure-js-dev-tools": "^0.6.0",
     "@types/chai": "^4.1.4",
     "@types/mocha": "^5.2.1",
     "@types/node": "^10.9.4",
-    "chai": "^4.1.2",
-    "mocha": "^5.2.0",
-    "mocha-junit-reporter": "^1.18.0",
+    "chai": "^4.2.0",
+    "mocha": "^6.1.4",
+    "mocha-junit-reporter": "^1.23.0",
     "mocha-multi-reporters": "^1.1.7",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
-    "opn-cli": "^4.0.0",
-    "rollup": "^0.67.3",
-    "rollup-plugin-node-resolve": "^3.4.0",
+    "open-cli": "^5.0.0",
+    "rollup": "^1.17.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-visualizer": "^0.9.2",
+    "rollup-plugin-visualizer": "^2.4.4",
     "shx": "^0.3.2",
-    "ts-loader": "^5.3.1",
-    "ts-node": "^7.0.1",
-    "tslint": "^5.7.0",
-    "typescript": "^3.1.1",
-    "uglify-js": "^3.4.9",
-    "yarn": "^1.6.0"
+    "ts-loader": "^6.0.4",
+    "ts-node": "^8.3.0",
+    "tslint": "^5.18.0",
+    "typescript": "^3.5.3",
+    "uglify-js": "^3.6.0",
+    "yarn": "^1.17.3"
   },
   "homepage": "https://github.com/Azure/ms-rest-azure-js",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ const config = {
     banner
   },
   plugins: [
-    nodeResolve({ module: true }),
+    nodeResolve({ mainFields: ["module", "main"]}),
     sourcemaps(),
     visualizer({ filename: "dist/node-stats.html", sourcemap: true })
   ]


### PR DESCRIPTION
- Bumping the version to `2.0.0` since the underlying dependency `@azure/ms-rest-js` has moved to `2.x.x` range.
  - `@azure/ms-rest-js@2.x.x` is using `node-fetch` instead of `axios` as the http client for node.js scenario.
  - We have made some bug fixes to handling cookie parsing errors in the `2.0.3` version
  - This helps us in making it easier to update the autorest generated TypeScript sdk packages on an on-demand basis and keeping sdks from unnecessarily getting runtime updates when they are eventually going to get updated to use the new `@azure/core-*` runtime packages in couple of weeks from now.