### PR TITLE
set response.parsedBody as-is if the response body sent by the service is a string instead of a JSON object.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.0.1 - 2019-07-30
+- In `getOperationResponse()` if the `resource` is of type `string` and we get an error while performing `JSON.parse()` then instead of letting the error be thrown we set the `resource` as-is as the `response.parsedBody`
+
 ## 2.0.0 - 2019-07-15
 - Bumping the version to `2.0.0` since the underlying dependency `@azure/ms-rest-js` has moved to `2.x.x` range.
   - `@azure/ms-rest-js@2.x.x` is using `node-fetch` instead of `axios` as the http client for node.js scenario.

--- a/lib/lroPollStrategy.ts
+++ b/lib/lroPollStrategy.ts
@@ -86,7 +86,13 @@ export abstract class LROPollStrategy {
       result.parsedBody = response.parsedBody;
     } else if (typeof resource.valueOf() === "string") {
       result.bodyAsText = resource;
-      result.parsedBody = JSON.parse(resource);
+      try {
+        result.parsedBody = JSON.parse(resource);
+      } catch (err) {
+        // There was an error parsing the JSON. Hence we set the resource as-is. Most likely, the
+        // resource is a string that was already parsed.
+        result.parsedBody = resource;
+      }
     } else {
       result.bodyAsText = JSON.stringify(resource);
       result.parsedBody = resource;

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -27,4 +27,4 @@ export const DEFAULT_LANGUAGE = "en-us";
  * @const
  * @type {string}
  */
-export const msRestAzureVersion = "2.0.0";
+export const msRestAzureVersion = "2.0.1";

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-azure-js"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Isomorphic Azure client runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@azure/ms-rest-js": "^2.0.3",
+    "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Corresponding update in ms-rest-js https://github.com/Azure/ms-rest-js/pull/369 `"@azure/ms-rest-js": "^2.0.4"`
- Have manually tested the changes in ms-rest-js and ms-rest-azure-js in autorest.typescript generator and all tests in the generator are passing
```bash
amarz-MBP:autorest.typescript amarz$ sudo gulp test
[19:45:35] Using gulpfile ~/sdk/autorest.typescript/gulpfile.js
[19:45:35] Starting 'init'...
[19:45:35] Finished 'init' after 379 μs
[19:45:35] Starting 'test/generator-unit'...
           /Users/amarz/sdk/autorest.typescript :: dotnet test /Users/amarz/sdk/autorest.typescript/unittests/autorest.typescript.tests.csproj /nologo
[19:45:35] Starting 'test/typecheck'...
           /Users/amarz/sdk/autorest.typescript :: /Users/amarz/sdk/autorest.typescript/node_modules/.bin/tsc -p /Users/amarz/sdk/autorest.typescript/test/tsconfig.generated.json
[19:45:41] Finished 'test/generator-unit' after 5.2 s
[19:45:41] Finished 'test/typecheck' after 5.82 s
[19:45:41] Starting 'test/'...
[19:45:41] Starting 'init'...
[19:45:41] Finished 'init' after 3.2 μs
[19:45:41] Starting 'test/vanilla-metadata'...
           /Users/amarz/sdk/autorest.typescript/test/metadata/generated/BodyComplex :: npm install
[19:45:41] Starting 'test/azure-metadata'...
           /Users/amarz/sdk/autorest.typescript/test/azuremetadata/generated/Lro :: npm install
[19:45:42] Finished 'test/azure-metadata' after 1.07 s
[19:45:42] Finished 'test/vanilla-metadata' after 1.13 s
[19:45:42] Starting 'test/metadata'...
[19:45:42] Finished 'test/metadata' after 33 μs
[19:45:42] Starting 'init'...
[19:45:42] Finished 'init' after 4 μs
[19:45:42] Starting 'test/multiapi'...
           /Users/amarz/sdk/autorest.typescript/test/multiapi :: npm install
           /Users/amarz/sdk/autorest.typescript/test/multiapi :: npm run build
[19:45:55] Finished 'test/multiapi' after 13 s
[19:45:55] Starting 'test/nodejs-unit'...
           /Users/amarz/sdk/autorest.typescript :: /Users/amarz/sdk/autorest.typescript/node_modules/.bin/mocha
[19:46:03] Finished 'test/nodejs-unit' after 8.29 s
[19:46:03] Finished 'test/' after 22 s
[19:46:03] Starting 'test'...
[19:46:03] Finished 'test' after 53 μs
amarz-MBP:autorest.typescript amarz$
```